### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/frinen3/76509d82-13a9-4824-b98e-2746695951f6/5026388c-d543-4528-9c07-c093aa7b8515/_apis/work/boardbadge/df17a359-b417-4794-ac2e-2e4de0707b07)](https://dev.azure.com/frinen3/76509d82-13a9-4824-b98e-2746695951f6/_boards/board/t/5026388c-d543-4528-9c07-c093aa7b8515/Microsoft.RequirementCategory)
 # CheAuto
 [![Build Status](https://dev.azure.com/frinen3/CheAuto/_apis/build/status/Frinen.CheAuto?branchName=master)](https://dev.azure.com/frinen3/CheAuto/_build/latest?definitionId=4&branchName=master)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#394](https://dev.azure.com/frinen3/76509d82-13a9-4824-b98e-2746695951f6/_workitems/edit/394). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.